### PR TITLE
fixes/location-submit-crash

### DIFF
--- a/app/src/main/java/com/github/codetanzania/ui/fragment/SelectLocationFragment.java
+++ b/app/src/main/java/com/github/codetanzania/ui/fragment/SelectLocationFragment.java
@@ -298,7 +298,7 @@ public class SelectLocationFragment extends MapboxBaseFragment implements
     @Override
     public void onClick(View v) {
         if (v == mSubmitButton) {
-            if (mSubmitListener == null) {
+            if (mSubmitListener == null || mCurrentLocation == null || mAddress == null) {
                 return;
             }
             // Get location coordinates


### PR DESCRIPTION
Submit button was enabled before current location was found, causing a null pointer exception. Now it is disabled until current location and address are found.