### PR TITLE
Fixes/vector drawables pre lolly

### DIFF
--- a/app/src/main/java/com/github/codetanzania/DAWASCOApp.java
+++ b/app/src/main/java/com/github/codetanzania/DAWASCOApp.java
@@ -1,5 +1,10 @@
 package com.github.codetanzania;
 
 import android.app.Application;
+import android.support.v7.app.AppCompatDelegate;
 
-public class DAWASCOApp extends Application {}
+public class DAWASCOApp extends Application {
+    static {
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
+    }
+}

--- a/app/src/main/java/com/github/codetanzania/api/location/LocationTracker.java
+++ b/app/src/main/java/com/github/codetanzania/api/location/LocationTracker.java
@@ -87,7 +87,7 @@ public class LocationTracker implements
 
     // This must be called in Activity onPause() to avoid memory leaks.
     public void onPause() {
-        if (mGoogleApiClient != null) {
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
             LocationServices.FusedLocationApi.removeLocationUpdates(mGoogleApiClient, this);
         }
     }

--- a/app/src/main/java/com/github/codetanzania/ui/fragment/SelectLocationFragment.java
+++ b/app/src/main/java/com/github/codetanzania/ui/fragment/SelectLocationFragment.java
@@ -301,7 +301,8 @@ public class SelectLocationFragment extends MapboxBaseFragment implements
     @Override
     public void onClick(View v) {
         if (v == mSubmitButton) {
-            if (mSubmitListener == null || mCurrentLocation == null || mAddress == null) {
+            // TODO Fetching address should not be tied to fragment
+            if (mSubmitListener == null || mCurrentLocation == null /*|| mAddress == null */) {
                 return;
             }
             // Get location coordinates

--- a/app/src/main/res/drawable/ic_access_time_gray_24dp_wrapper.xml
+++ b/app/src/main/res/drawable/ic_access_time_gray_24dp_wrapper.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_access_time_gray_24dp" />
+</selector>

--- a/app/src/main/res/drawable/ic_chevron_right_accent_24dp_wrapper.xml
+++ b/app/src/main/res/drawable/ic_chevron_right_accent_24dp_wrapper.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_chevron_right_accent_24dp" />
+</selector>

--- a/app/src/main/res/drawable/ic_cloud_off_48x48_wrapper.xml
+++ b/app/src/main/res/drawable/ic_cloud_off_48x48_wrapper.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_cloud_off_48x48" />
+</selector>

--- a/app/src/main/res/drawable/ic_format_list_bulleted_black_48dp_wrapper.xml
+++ b/app/src/main/res/drawable/ic_format_list_bulleted_black_48dp_wrapper.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_format_list_bulleted_black_48dp" />
+</selector>

--- a/app/src/main/res/drawable/ic_location_on_black_12dp_wrapper.xml
+++ b/app/src/main/res/drawable/ic_location_on_black_12dp_wrapper.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_location_on_black_12dp" />
+</selector>

--- a/app/src/main/res/drawable/ic_refresh_blue_24dp_wrapper.xml
+++ b/app/src/main/res/drawable/ic_refresh_blue_24dp_wrapper.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_refresh_blue_24dp" />
+</selector>

--- a/app/src/main/res/drawable/ic_send_24dp_wrapper.xml
+++ b/app/src/main/res/drawable/ic_send_24dp_wrapper.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_send_24dp" />
+</selector>

--- a/app/src/main/res/drawable/ic_view_list_black_24dp_wrapper.xml
+++ b/app/src/main/res/drawable/ic_view_list_black_24dp_wrapper.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_view_list_black_24dp" />
+</selector>

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -11,7 +11,7 @@
         android:layout_height="match_parent"
         android:layout_centerInParent="true"
         android:scaleType="centerCrop"
-        android:src="@drawable/intro_background"
+        app:srcCompat="@drawable/intro_background"
         tools:ignore="ContentDescription"/>
 
     <FrameLayout

--- a/app/src/main/res/layout/card_view_quick_issue_selector.xml
+++ b/app/src/main/res/layout/card_view_quick_issue_selector.xml
@@ -69,7 +69,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     style="?android:attr/borderlessButtonStyle"
-                    android:drawableStart="@drawable/ic_format_list_bulleted_black_48dp"
+                    android:drawableStart="@drawable/ic_format_list_bulleted_black_48dp_wrapper"
                     android:layout_gravity="start|center_vertical"
                     android:text="@string/text_view_categories"
                     android:textColor="#999999"

--- a/app/src/main/res/layout/cardview_issue_attachment.xml
+++ b/app/src/main/res/layout/cardview_issue_attachment.xml
@@ -24,7 +24,7 @@
             android:layout_height="wrap_content"
             android:scaleType="center"
             android:layout_gravity="center"
-            android:src="@drawable/ic_mic_black_24dp"
+            app:srcCompat="@drawable/ic_mic_black_24dp"
             android:contentDescription="@string/text_issue_attachment" />
 
         <TextView

--- a/app/src/main/res/layout/frag_empty_issue_tickets.xml
+++ b/app/src/main/res/layout/frag_empty_issue_tickets.xml
@@ -3,6 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:gravity="center"
     android:layout_centerInParent="true">
 
     <ImageView

--- a/app/src/main/res/layout/frag_err.xml
+++ b/app/src/main/res/layout/frag_err.xml
@@ -3,6 +3,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_gravity="center"
     android:gravity="center"
     android:background="@color/gray">
 
@@ -16,7 +17,7 @@
         android:text="@string/msg_server_error"
         android:textAlignment="center"
         android:drawablePadding="8dp"
-        android:drawableTop="@drawable/ic_cloud_off_48x48" />
+        android:drawableTop="@drawable/ic_cloud_off_48x48_wrapper" />
 
     <!-- The retry again button allows user to refresh the page -->
     <Button
@@ -24,7 +25,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         style="?android:attr/borderlessButtonStyle"
-        android:drawableStart="@drawable/ic_refresh_blue_24dp"
+        android:drawableStart="@drawable/ic_refresh_blue_24dp_wrapper"
         android:textColor="@color/colorAccent"
         android:text="@string/action_reload"/>
 

--- a/app/src/main/res/layout/frag_image_attachment.xml
+++ b/app/src/main/res/layout/frag_image_attachment.xml
@@ -10,7 +10,7 @@
         android:layout_width="92dp"
         android:layout_height="92dp"
         android:layout_centerInParent="true"
-        android:src="@drawable/ic_add_a_photo_black_24dp"
+        app:srcCompat="@drawable/ic_add_a_photo_black_24dp"
         app:civ_border_width="2dp"
         app:civ_border_color="@color/colorAccent"/>
 

--- a/app/src/main/res/layout/frag_issue_description.xml
+++ b/app/src/main/res/layout/frag_issue_description.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
@@ -26,7 +26,7 @@
         android:drawablePadding="8dp"
         android:layout_marginTop="16dp"
         android:layout_marginBottom="16dp"
-        android:src="@drawable/ic_add_a_photo_black_24dp"/>
+        app:srcCompat="@drawable/ic_add_a_photo_black_24dp"/>
 
     <LinearLayout
         android:id="@+id/ll_NextAction"
@@ -42,7 +42,7 @@
         <ImageButton
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_mic_black_24dp"
+            app:srcCompat="@drawable/ic_mic_black_24dp"
             style="?attr/borderlessButtonStyle"
             android:layout_weight="1"
             android:contentDescription="@string/text_record_audio" />

--- a/app/src/main/res/layout/frag_issue_description.xml
+++ b/app/src/main/res/layout/frag_issue_description.xml
@@ -64,7 +64,7 @@
             android:text="@string/action_send"
             android:textColor="@color/colorAccent"
             style="?attr/borderlessButtonStyle"
-            android:drawableEnd="@drawable/ic_send_24dp"/>
+            android:drawableEnd="@drawable/ic_send_24dp_wrapper"/>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/frag_issue_description_alt.xml
+++ b/app/src/main/res/layout/frag_issue_description_alt.xml
@@ -25,8 +25,6 @@
                 android:text="@string/text_issue_title"
                 android:textStyle="bold"
                 android:layout_marginTop="16dp"/>
-                android:layout_marginTop="16dp"
-                android:layout_marginBottom="16dp"/>
 
             <EditText
                 android:id="@+id/et_IssueTitle"
@@ -47,8 +45,6 @@
                 android:text="@string/text_issue_photos"
                 android:textStyle="bold"
                 android:layout_marginTop="16dp"/>
-                android:layout_marginTop="16dp"
-                android:layout_marginBottom="16dp"/>
 
             <LinearLayout
                 android:id="@+id/ll_Photos"
@@ -77,51 +73,49 @@
 
             </LinearLayout>
 
-        </LinearLayout>
+            <LinearLayout
+                android:id="@+id/ll_IssueTextDetails"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:paddingEnd="16dp"
+                android:paddingStart="16dp"
+                android:layout_marginBottom="16dp"
+                android:background="@color/colorPrimary">
 
+                <TextView
+                    android:id="@+id/tv_IssueDescriptions"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/title_issue_description"
+                    android:textStyle="bold"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="16dp"/>
+
+                <EditText
+                    android:id="@+id/et_IssueDescription"
+                    android:inputType="textMultiLine"
+                    android:minLines="2"
+                    android:padding="10dp"
+                    android:gravity="top|start"
+                    android:hint="@string/text_issue_description_hint"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/bg_default_text_edit" />
+
+                <Button
+                    android:id="@+id/btn_SubmitIssue"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:foreground="?android:attr/selectableItemBackground"
+                    android:background="@color/colorAccent"
+                    android:text="@string/text_submit"
+                    android:textColor="@android:color/white" />
+
+            </LinearLayout>
+        </LinearLayout>
     </ScrollView>
 
-    <LinearLayout
-        android:id="@+id/ll_IssueTextDetails"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_alignParentBottom="true"
-        android:paddingEnd="16dp"
-        android:paddingStart="16dp"
-        android:layout_marginBottom="16dp"
-        android:background="@color/colorPrimary">
-
-        <TextView
-            android:id="@+id/tv_IssueDescriptions"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/title_issue_description"
-            android:textStyle="bold"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"/>
-
-        <EditText
-            android:id="@+id/et_IssueDescription"
-            android:inputType="textMultiLine"
-            android:minLines="5"
-            android:padding="10dp"
-            android:gravity="top|start"
-            android:hint="@string/text_issue_description_hint"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/bg_default_text_edit" />
-
-        <Button
-            android:id="@+id/btn_SubmitIssue"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:foreground="?android:attr/selectableItemBackground"
-            android:background="@color/colorAccent"
-            android:text="@string/text_submit"
-            android:textColor="@android:color/white" />
-
-    </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/frag_location.xml
+++ b/app/src/main/res/layout/frag_location.xml
@@ -66,7 +66,7 @@
             android:layout_height="wrap_content"
             android:text="@string/use_location"
             android:layout_gravity="center"
-            android:drawableEnd="@drawable/ic_chevron_right_accent_24dp"/>
+            android:drawableEnd="@drawable/ic_chevron_right_accent_24dp_wrapper"/>
 
         <Button
             android:id="@+id/btn_ChangeAddress"
@@ -75,7 +75,7 @@
             android:layout_height="wrap_content"
             android:text="@string/change_address"
             android:layout_gravity="center"
-            android:drawableEnd="@drawable/ic_chevron_right_accent_24dp"/>
+            android:drawableEnd="@drawable/ic_chevron_right_accent_24dp_wrapper"/>
 
         <!--<Button-->
             <!--android:id="@id/btn_Next"-->
@@ -84,7 +84,7 @@
             <!--android:layout_height="wrap_content"-->
             <!--android:text="Why do we need this information?"-->
             <!--android:layout_gravity="center"-->
-            <!--android:drawableEnd="@drawable/ic_chevron_right_accent_24dp"/>-->
+            <!--android:drawableEnd="@drawable/ic_chevron_right_accent_24dp_wrapper"/>-->
 
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/frag_open_issue_ticket.xml
+++ b/app/src/main/res/layout/frag_open_issue_ticket.xml
@@ -51,7 +51,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:drawableStart="@drawable/ic_location_on_black_12dp"
-                    android:textSize="10sp"/>
+                    android:textSize="12sp"/>
 
                 <Button
                     android:id="@+id/btn_GetLocation"
@@ -76,7 +76,7 @@
             <ImageButton
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:src="@drawable/ic_mic_black_24dp"
+                app:srcCompat="@drawable/ic_mic_black_24dp"
                 style="?attr/borderlessButtonStyle"
                 android:layout_weight="1"
                 android:contentDescription="@string/text_record_audio" />

--- a/app/src/main/res/layout/frag_open_issue_ticket.xml
+++ b/app/src/main/res/layout/frag_open_issue_ticket.xml
@@ -50,7 +50,7 @@
                     android:id="@+id/tv_CurrentLocation"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:drawableStart="@drawable/ic_location_on_black_12dp"
+                    android:drawableStart="@drawable/ic_location_on_black_12dp_wrapper"
                     android:textSize="12sp"/>
 
                 <Button
@@ -98,7 +98,7 @@
                 android:text="@string/action_send"
                 android:textColor="@color/colorAccent"
                 style="?attr/borderlessButtonStyle"
-                android:drawableEnd="@drawable/ic_send_24dp"/>
+                android:drawableEnd="@drawable/ic_send_24dp_wrapper"/>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/frag_recent_media_items.xml
+++ b/app/src/main/res/layout/frag_recent_media_items.xml
@@ -8,7 +8,7 @@
         android:id="@+id/tv_MediaTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:drawableEnd="@drawable/ic_view_list_black_24dp"
+        android:drawableEnd="@drawable/ic_view_list_black_24dp_wrapper"
         style="@style/TitleTextAppearance"
         android:text="@string/title_reported_issue"
         android:textAllCaps="true"
@@ -91,7 +91,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:drawableTop="@drawable/ic_cloud_off_48x48"
+                android:drawableTop="@drawable/ic_cloud_off_48x48_wrapper"
                 android:text="@string/msg_network_error"
                 android:drawablePadding="16dip"/>
 

--- a/app/src/main/res/layout/issue_timeline_view.xml
+++ b/app/src/main/res/layout/issue_timeline_view.xml
@@ -11,7 +11,7 @@
         android:id="@+id/timeline_Marker"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        app:marker="@drawable/ic_access_time_gray_24dp"
+        app:marker="@drawable/ic_access_time_gray_24dp_wrapper"
         app:markerSize="20dp"
         app:line="@color/colorPrimaryDark"
         app:lineSize="1dp"/>
@@ -38,7 +38,7 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentTop="true"
                 android:layout_alignParentStart="true"
-                android:textSize="10sp"/>
+                android:textSize="12sp"/>
 
             <android.support.v7.widget.AppCompatTextView
                 android:id="@+id/tv_StatusContent"

--- a/app/src/main/res/layout/layout_dialog.xml
+++ b/app/src/main/res/layout/layout_dialog.xml
@@ -3,81 +3,74 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="#ffffff"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:padding="15dp">
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/spinerTitle"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="15dp"
-        android:orientation="vertical">
+        android:layout_height="wrap_content"
+        android:text="@string/action_select_issue_category"
+        android:textSize="17sp"
+        android:textStyle="bold" />
 
-        <TextView
-            android:id="@+id/spinerTitle"
-            android:layout_width="match_parent"
+    <!--<LinearLayout-->
+    <!--android:layout_width="match_parent"-->
+    <!--android:layout_height="wrap_content"-->
+    <!--android:gravity="center|start"-->
+    <!--android:orientation="horizontal">-->
+
+    <!--<ImageView-->
+    <!--android:layout_width="30dp"-->
+    <!--android:layout_height="30dp"-->
+    <!--app:srcCompat="@drawable/ic_search_black_36dp" />-->
+
+    <!--<EditText-->
+    <!--android:id="@+id/searchBox"-->
+    <!--android:layout_width="match_parent"-->
+    <!--android:layout_height="40dp"-->
+    <!--android:layout_marginStart="5dp"-->
+    <!--android:background="#ffffff"-->
+    <!--android:inputType="text" />-->
+
+    <!--</LinearLayout>-->
+
+    <!--<View-->
+    <!--android:layout_width="wrap_content"-->
+    <!--android:layout_height="0.1dp"-->
+    <!--android:background="#d1d1d1" />-->
+
+    <ListView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="300dp"
+        android:divider="@color/colorItemsSeparator"
+        android:dividerHeight="0.1dp" />
+
+    <RelativeLayout
+        android:id="@+id/linear_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/select"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/action_select_issue_category"
-            android:textSize="17sp"
-            android:textStyle="bold" />
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:text="@string/action_select" />
 
-        <!--<LinearLayout-->
-            <!--android:layout_width="match_parent"-->
-            <!--android:layout_height="wrap_content"-->
-            <!--android:gravity="center|start"-->
-            <!--android:orientation="horizontal">-->
-
-            <!--<ImageView-->
-                <!--android:layout_width="30dp"-->
-                <!--android:layout_height="30dp"-->
-                <!--android:src="@drawable/ic_search_black_36dp" />-->
-
-            <!--<EditText-->
-                <!--android:id="@+id/searchBox"-->
-                <!--android:layout_width="match_parent"-->
-                <!--android:layout_height="40dp"-->
-                <!--android:layout_marginStart="5dp"-->
-                <!--android:background="#ffffff"-->
-                <!--android:inputType="text" />-->
-
-        <!--</LinearLayout>-->
-
-        <!--<View-->
-            <!--android:layout_width="wrap_content"-->
-            <!--android:layout_height="0.1dp"-->
-            <!--android:background="#d1d1d1" />-->
-
-        <ListView
-            android:id="@+id/list"
-            android:layout_width="match_parent"
-            android:layout_height="300dp"
-            android:divider="@color/colorItemsSeparator"
-            android:dividerHeight="0.1dp" />
-
-        <RelativeLayout
-            android:id="@+id/linear_layout"
-            android:layout_width="match_parent"
+        <Button
+            android:id="@+id/close"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:layout_alignParentStart="true"
+            android:layout_toStartOf="@id/select"
+            android:layout_centerVertical="true"
+            android:text="@string/action_close" />
 
-            <Button
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_centerVertical="true"
-                android:layout_alignParentEnd="true"
-                android:id="@+id/select"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/action_select"/>
-
-            <Button
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_centerVertical="true"
-                android:layout_alignParentStart="true"
-                android:id="@+id/close"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/action_close" />
-
-        </RelativeLayout>
-
-    </LinearLayout>
-
+    </RelativeLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/profile_content_scrolling.xml
+++ b/app/src/main/res/layout/profile_content_scrolling.xml
@@ -105,7 +105,7 @@
                 <!--android:layout_height="wrap_content"-->
                 <!--android:layout_centerVertical="true"-->
                 <!--android:layout_marginEnd="@dimen/activity_horizontal_margin"-->
-                <!--android:src="@drawable/ic_place_black_24dp"-->
+                <!--app:srcCompat="@drawable/ic_place_black_24dp"-->
                 <!--android:contentDescription="@string/text_user_location" />-->
 
             <!--<TextView-->
@@ -143,7 +143,7 @@
                 <!--android:layout_height="wrap_content"-->
                 <!--android:layout_centerVertical="true"-->
                 <!--android:layout_marginEnd="@dimen/activity_horizontal_margin"-->
-                <!--android:src="@drawable/ic_place_black_24dp"-->
+                <!--app:srcCompat="@drawable/ic_place_black_24dp"-->
                 <!--android:visibility="invisible"-->
                 <!--android:contentDescription="@string/text_user_meter_number" />-->
 


### PR DESCRIPTION
Note: 

Going forward to make the app work on lower API levels ensure to:

- replace `android:src` with `app:srcCompat`
- use wrappers around vectors when using `android:drawableTop`, `android:drawableBottom`, `android:drawableStart`, or `android:drawableEnd`. 