### PR TITLE
Fixes/issue list/add fab event

### DIFF
--- a/app/src/main/java/com/github/codetanzania/ui/activity/IssueListActivity.java
+++ b/app/src/main/java/com/github/codetanzania/ui/activity/IssueListActivity.java
@@ -1,5 +1,7 @@
 package com.github.codetanzania.ui.activity;
 
+import android.content.Intent;
+import android.content.res.ColorStateList;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -16,6 +18,7 @@ import com.github.codetanzania.api.Open311Api;
 import com.github.codetanzania.api.model.Open311Service;
 import com.github.codetanzania.model.Reporter;
 import com.github.codetanzania.model.ServiceRequest;
+import com.github.codetanzania.model.adapter.ServiceRequests;
 import com.github.codetanzania.ui.IssueCategoryPickerDialog;
 import com.github.codetanzania.ui.fragment.EmptyIssuesFragment;
 import com.github.codetanzania.ui.fragment.ErrorFragment;
@@ -27,6 +30,7 @@ import com.github.codetanzania.util.ServiceRequestsUtil;
 import com.github.codetanzania.util.Util;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import okhttp3.ResponseBody;
 import retrofit2.Call;
@@ -287,11 +291,11 @@ public class IssueListActivity extends RetrofitActivity<ResponseBody>
 
     @Override
     public void onIssueCategorySelected(Open311Service open311Service) {
-        /*Intent intent = new Intent(this, ReportIssueActivity.class);
+        Intent intent = new Intent(this, ReportIssueActivity.class);
         Bundle extras = new Bundle();
         extras.putParcelable(ReportIssueActivity.TAG_SELECTED_SERVICE, open311Service);
         intent.putExtras(extras);
-        startActivityForResult(intent, REQUEST_CODE_REPORT_ISSUE);*/
-        Toast.makeText(this, "This button is a work in progress", Toast.LENGTH_SHORT).show();
+        startActivityForResult(intent, 1);
+        Toast.makeText(this, "KNOWN BUG: Reported issue will not appear in a list of recently reported issues", Toast.LENGTH_SHORT).show();
     }
 }

--- a/app/src/main/java/com/github/codetanzania/ui/activity/IssueListActivity.java
+++ b/app/src/main/java/com/github/codetanzania/ui/activity/IssueListActivity.java
@@ -1,7 +1,5 @@
 package com.github.codetanzania.ui.activity;
 
-import android.content.Intent;
-import android.content.res.ColorStateList;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -15,13 +13,16 @@ import android.widget.Toast;
 
 import com.github.codetanzania.adapter.OnItemClickListener;
 import com.github.codetanzania.api.Open311Api;
+import com.github.codetanzania.api.model.Open311Service;
 import com.github.codetanzania.model.Reporter;
 import com.github.codetanzania.model.ServiceRequest;
+import com.github.codetanzania.ui.IssueCategoryPickerDialog;
 import com.github.codetanzania.ui.fragment.EmptyIssuesFragment;
 import com.github.codetanzania.ui.fragment.ErrorFragment;
 import com.github.codetanzania.ui.fragment.ProgressBarFragment;
 import com.github.codetanzania.ui.fragment.ServiceRequestsTabFragment;
 import com.github.codetanzania.util.LookAndFeelUtils;
+import com.github.codetanzania.util.Open311ServicesUtil;
 import com.github.codetanzania.util.ServiceRequestsUtil;
 import com.github.codetanzania.util.Util;
 
@@ -38,7 +39,7 @@ import tz.co.codetanzania.R;
 public class IssueListActivity extends RetrofitActivity<ResponseBody>
     implements ErrorFragment.OnReloadClickListener,
         Callback<ResponseBody>,
-        OnItemClickListener<ServiceRequest> {
+        OnItemClickListener<ServiceRequest>,IssueCategoryPickerDialog.OnSelectIssueCategory {
 
     /* used by the logcat */
     private static final String TAG = "TicketGroupsActivity";
@@ -56,6 +57,9 @@ public class IssueListActivity extends RetrofitActivity<ResponseBody>
     private boolean showMenu = true;
 
     private boolean startRefresh = false;
+
+    /* IssuePicker Dialog */
+    private IssueCategoryPickerDialog pickerDialog;
 
     /*
      * TODO: Add search and profile.
@@ -75,8 +79,7 @@ public class IssueListActivity extends RetrofitActivity<ResponseBody>
         mFab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent createIssueIntent = new Intent(v.getContext(), ReportIssueActivity.class);
-                startActivity(createIssueIntent);
+                showIssueCategoryPickerDialog();
             }
         });
     }
@@ -167,6 +170,16 @@ public class IssueListActivity extends RetrofitActivity<ResponseBody>
                 .replace(R.id.frl_TicketsActivity, frag)
                 .disallowAddToBackStack()
                 .commitAllowingStateLoss();
+    }
+
+    private void showIssueCategoryPickerDialog() {
+        if (pickerDialog == null) {
+            ArrayList<Open311Service> list = (ArrayList<Open311Service>)
+                    Open311ServicesUtil.cached(this);
+            pickerDialog =
+                    new IssueCategoryPickerDialog(list, this);
+        }
+        pickerDialog.show();
     }
 
     private void showListTabs(ArrayList<ServiceRequest> requests) {
@@ -270,5 +283,15 @@ public class IssueListActivity extends RetrofitActivity<ResponseBody>
     public void onItemClick(ServiceRequest theItem) {
         // preview the item which was clicked
         Util.startPreviewIssueActivity(this, theItem);
+    }
+
+    @Override
+    public void onIssueCategorySelected(Open311Service open311Service) {
+        /*Intent intent = new Intent(this, ReportIssueActivity.class);
+        Bundle extras = new Bundle();
+        extras.putParcelable(ReportIssueActivity.TAG_SELECTED_SERVICE, open311Service);
+        intent.putExtras(extras);
+        startActivityForResult(intent, REQUEST_CODE_REPORT_ISSUE);*/
+        Toast.makeText(this, "This button is a work in progress", Toast.LENGTH_SHORT).show();
     }
 }

--- a/app/src/main/java/com/github/codetanzania/ui/activity/ReportIssueActivity.java
+++ b/app/src/main/java/com/github/codetanzania/ui/activity/ReportIssueActivity.java
@@ -190,7 +190,8 @@ public class ReportIssueActivity extends BaseAppFragmentActivity implements
         // if no data was previously cached, then fetch
         if (cachedData.isEmpty()) {
             // show progress-dialog while we're loading data from the server.
-            ProgressDialog dialog = ProgressDialog.show(this, getString(R.string.title_loading_services), getString(R.string.text_loading_services), true);
+            ProgressDialog dialog = ProgressDialog
+                    .show(this, getString(R.string.title_loading_services), getString(R.string.text_loading_services), true);
             String authHeader = getSharedPreferences(Constants.Const.KEY_SHARED_PREFS, MODE_PRIVATE)
                     .getString(Constants.Const.AUTH_TOKEN, null);
             Call<ResponseBody> call = new Open311Api.ServiceBuilder(this).build(Open311Api.ServicesEndpoint.class)
@@ -210,6 +211,8 @@ public class ReportIssueActivity extends BaseAppFragmentActivity implements
                 if (dialog.isShowing()) {
                     dialog.dismiss();
                 }
+
+
                 if (response.isSuccessful()) {
 
                     List<Open311Service> list = new ArrayList<>();


### PR DESCRIPTION
Showing Dialog picker when the fab button from the issues-list page is clicked.
Display a warning toast about unfinished work. The bug is to be fixed when posting issues using services is implemented.